### PR TITLE
Ballot FORUM-XX: Allow relative effective dates in ballots

### DIFF
--- a/Bylaws.md
+++ b/Bylaws.md
@@ -112,7 +112,8 @@ This section applies to any ballot that proposes a Final Guideline or a Final Ma
     * The Table of Contents,
     * The year in the “Copyright” information,
     * Footers with page numbers,
-    * Links to other sections within the document.    
+    * Links to other sections within the document, and
+    * Reifying relative effective dates (e.g. "6 months after publication") into absolute dates (e.g. "Month DD, YYYY").
 
     The Chair or Vice-Chair of the Forum or of a CWG is also allowed to perform the following changes, unless the ballot explicitly updates this information:
    
@@ -120,7 +121,6 @@ This section applies to any ballot that proposes a Final Guideline or a Final Ma
     * Headers/Footers with version numbers,
     * The table with document revisions or Document History,
     * The table with Relevant Dates.
-    
 
  9. If Exclusion Notice(s) are filed during the Review Period (as described in Section 4.3 of the IPR Policy), then the results of the Initial Vote are automatically rescinded and deemed null and void, and;
 


### PR DESCRIPTION
Allow the Chair or Vice Chair of the Forum or a Working Group to update relative effective dates found within a ballot into concrete dates when publishing a Final Guideline or Final Maintenance Guideline.

This allows ballots to contain statements like "Effective [6 months after publication], CAs MUST...", which the Chair would then convert to "Effective Jan 15, 2026, CAs MUST". This allows the ballot writing and discussion process to focus on the length of the necessary transition/implementation period, rather than on the specific effective date, preventing ballots from needing to be re-proposed simply because the discussion period has taken longer than expected and now the effective date is too close.