### PR TITLE
Various workflow TLC

### DIFF
--- a/.github/workflows/build-draft-docs.yml
+++ b/.github/workflows/build-draft-docs.yml
@@ -11,16 +11,16 @@ jobs:
           - 'SCWG-charter.md'
           - 'SMCWG-charter.md'
     name: Build ${{ matrix.document }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Checkout old version for redline (pull request)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.push.before }}
           path: old/
-      - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.1.1
+      - uses: docker://ghcr.io/cabforum/build-guidelines-action:2.1.2
         id: build_doc
         with:
           markdown_file: ${{ matrix.document }}


### PR DESCRIPTION
- Use `ubuntu-latest` as runner
- Bump build guidelines action to @v2.1.2 (consistent with other WGs)
- Bump checkout action to @v4